### PR TITLE
explicitly make studio.sh executable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,3 +31,5 @@ parts:
   android-studio:
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.0.18/android-studio-ide-171.4408382-linux.zip
+    install: |
+      chmod 0755 $SNAPCRAFT_PART_INSTALL/android-studio/bin/studio.sh


### PR DESCRIPTION
Due to whatever reason the main entrypoint is not excutable when android-studio is installed from Store. This explictly makes it executable.