### PR TITLE
Revert "explicitly make studio.sh executable"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,5 +31,3 @@ parts:
   android-studio:
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.0.18/android-studio-ide-171.4408382-linux.zip
-    install: |
-      chmod 0755 $SNAPCRAFT_PART_INSTALL/android-studio/bin/studio.sh


### PR DESCRIPTION
Currently AndroidStudio is not runnable because the version of snapcraft in xenial is `2.34` which is being used by `build.snapcraft.io` infrastructure. There is a fix for that in `2.35`, though seems there is going to be a bit of a wait for that to get released for xenial.

Once that makes into xenial-updates, we will land this PR, resulting in a working AndroidStudio.

reference: https://forum.snapcraft.io/t/build-snapcraft-io-alters-breaks-file-permissions/2894