### PR TITLE
Ship packages required to run emulator

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,11 @@ apps:
     desktop: jetbrains-studio.desktop
 
 parts:
+  enable-i386:
+    plugin: nil
+    prepare: |
+      dpkg --add-architecture i386
+      apt update
   desktop:
     after:
       - android-studio
@@ -29,8 +34,7 @@ parts:
     prime:
       - jetbrains-studio.desktop
   android-studio:
-    prepare: |
-      dpkg --add-architecture i386
+    after: [enable-i386]
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.1.0/android-studio-ide-171.4443003-linux.zip
     stage-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,11 @@ apps:
     desktop: jetbrains-studio.desktop
 
 parts:
+  enable-i386:
+    plugin: nil
+    prepare: |
+      dpkg --add-architecture i386
+      apt update
   desktop:
     after:
       - android-studio
@@ -29,6 +34,7 @@ parts:
     prime:
       - jetbrains-studio.desktop
   android-studio:
+    after: [enable-i386]
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.1.0/android-studio-ide-171.4443003-linux.zip
     stage-packages:
@@ -37,4 +43,3 @@ parts:
       - libstdc++6:i386
       - libbz2-1.0:i386
       - lib32z1
-

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
   android-studio:
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.1.0/android-studio-ide-171.4443003-linux.zip
-    build-packages:
+    stage-packages:
       - libc6:i386
       - libncurses5:i386
       - libstdc++6:i386

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,4 +31,10 @@ parts:
   android-studio:
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.1.0/android-studio-ide-171.4443003-linux.zip
+    build-packages:
+      - libc6:i386
+      - libncurses5:i386
+      - libstdc++6:i386
+      - libbz2-1.0:i386
+      - lib32z1
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,11 +21,6 @@ apps:
     desktop: jetbrains-studio.desktop
 
 parts:
-  enable-i386:
-    plugin: nil
-    prepare: |
-      dpkg --add-architecture i386
-      apt update
   desktop:
     after:
       - android-studio
@@ -34,7 +29,8 @@ parts:
     prime:
       - jetbrains-studio.desktop
   android-studio:
-    after: [enable-i386]
+    prepare: |
+      dpkg --add-architecture i386
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.1.0/android-studio-ide-171.4443003-linux.zip
     stage-packages:


### PR DESCRIPTION
Android Studio requires some 32-bit libraries on 64-bit installs for the emulator to work. Ship those packages with the snap.

reference: https://developer.android.com/studio/install.html