### PR TITLE
Ship 32bit deps on 64bit build only

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,8 +38,9 @@ parts:
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.1.0/android-studio-ide-171.4443003-linux.zip
     stage-packages:
-      - libc6:i386
-      - libncurses5:i386
-      - libstdc++6:i386
-      - libbz2-1.0:i386
-      - zlib1g:i386
+      - on amd64:
+        - libc6:i386
+        - libncurses5:i386
+        - libstdc++6:i386
+        - libbz2-1.0:i386
+        - lib32z1


### PR DESCRIPTION
They are not needed on 32bit install[1] and it seems snapcraft have this nice feature, so lets use it.

[1] https://developer.android.com/studio/install.html