### PR TITLE
Export missing library paths

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ architectures:
 apps:
   android-studio:
     environment:
-      LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu:$SNAP/usr/lib/i386-linux-gnu:$SNAP/lib/i386-linux-gnu:$SNAP/usr/lib32:$SNAP/lib32:$LD_LIBRARY_PATH
+      LD_LIBRARY_PATH: $SNAP/usr/lib/i386-linux-gnu:$SNAP/lib/i386-linux-gnu:$SNAP/usr/lib32:$SNAP/lib32:$LD_LIBRARY_PATH
     command: android-studio/bin/studio.sh
     desktop: jetbrains-studio.desktop
 
@@ -40,9 +40,6 @@ parts:
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.1.0/android-studio-ide-171.4443003-linux.zip
     stage-packages:
-      - libxrender1
-      - libxtst6
-      - libxi6
       - on amd64:
         - libc6:i386
         - libncurses5:i386

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,4 +46,4 @@ parts:
         - lib32z1
       - libxrender1
       - libxtst6
-      - libxi6i
+      - libxi6

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,8 @@ architectures:
 
 apps:
   android-studio:
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu:$SNAP/usr/lib/i386-linux-gnu:$SNAP/lib/i386-linux-gnu:$SNAP/usr/lib32:$SNAP/lib32:$LD_LIBRARY_PATH
     command: android-studio/bin/studio.sh
     desktop: jetbrains-studio.desktop
 
@@ -38,12 +40,12 @@ parts:
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.1.0/android-studio-ide-171.4443003-linux.zip
     stage-packages:
+      - libxrender1
+      - libxtst6
+      - libxi6
       - on amd64:
         - libc6:i386
         - libncurses5:i386
         - libstdc++6:i386
         - libbz2-1.0:i386
         - lib32z1
-      - libxrender1
-      - libxtst6
-      - libxi6

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,3 +44,6 @@ parts:
         - libstdc++6:i386
         - libbz2-1.0:i386
         - lib32z1
+      - libxrender1
+      - libxtst6
+      - libxi6i


### PR DESCRIPTION
The stage packages that we were previously shipping with this snap were not being used as they were not added to the library path. Fix that.