### PR TITLE
Remove unneeded 32bit libraries

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,11 +21,6 @@ apps:
     desktop: jetbrains-studio.desktop
 
 parts:
-  enable-i386:
-    plugin: nil
-    prepare: |
-      dpkg --add-architecture i386
-      apt update
   desktop:
     after:
       - android-studio
@@ -34,13 +29,5 @@ parts:
     prime:
       - jetbrains-studio.desktop
   android-studio:
-    after: [enable-i386]
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.0.1.0/android-studio-ide-171.4443003-linux.zip
-    stage-packages:
-      - on amd64:
-        - libc6:i386
-        - libncurses5:i386
-        - libstdc++6:i386
-        - libbz2-1.0:i386
-        - lib32z1


### PR DESCRIPTION
Background: Previously we added these 32bit libraries into the snap believing they were required for the emulator to work, but from recent experience it seems that's not the case. At one stage in past, those libraries were indeed required for the Android Emulator to start but with recent version it *seems* they have removed the dependency on 32bit libraries.

On technical side, this is a classic snap and we need to explicitly export path of those staged libraries in the LD_LIBRARY_PATH and we are currently *not* doing that. So that means these staged packages are not actually being used.

So this PR basically removes the libraries cruft.

Shall the need arrive in future, we will fix that as needed.