### PR TITLE
Only support 64bit OS

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,6 @@ grade: stable
 confinement: classic
 architectures:
   - amd64
-  - i386
 
 apps:
   android-studio:


### PR DESCRIPTION
The upstream tarball contains 64bit JRE only, passively meaning that Google only cares about 64bit release. I think we should do the same.