### PR TITLE
release 3.1.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: android-studio
-version: '3.1.0.16'
+version: '3.1.1.0'
 summary: IDE for Android
 description: |
   Android Studio provides the fastest tools for building apps on every type
@@ -29,4 +29,4 @@ parts:
       - jetbrains-studio.desktop
   android-studio:
     plugin: dump
-    source: https://dl.google.com/dl/android/studio/ide-zips/3.1.0.16/android-studio-ide-173.4670197-linux.zip
+    source: https://dl.google.com/dl/android/studio/ide-zips/3.1.1.0/android-studio-ide-173.4697961-linux.zip


### PR DESCRIPTION
3.1.1 (April 2018)

This update to Android Studio 3.1 includes fixes for the following bugs:

    In some cases, when a project created in Android Studio 3.0 was opened for the first time in Android Studio 3.1, the Gradle-aware Make task was removed from the Before launch area in Run/Debug Configurations. The result was that projects did not build when the Run or Debug button was clicked, which in turn caused failures such as deployment of incorrect APKs and crashes when using Instant Run.

    To solve this problem, Android Studio 3.1.1 adds the Gradle-aware Make task to the run configuration for projects that are missing this entry. This modification occurs after the first Gradle sync when the project is loaded.
    The debugger crashed when debugging a layout with a text box if advanced profiling was enabled.
    Android Studio froze after you clicked Build Variants.
    AAR (Android archive) files were extracted twice, once during the Gradle sync process and once during the Gradle build process.
    Elements were missing from some vector drawables imported from SVG files.
    The warning regarding the deprecation of the compile dependency configuration has been updated with better guidance regarding the implementation and api configurations. For details of migrating away from using the compile configuration, see the documentation for the new dependency configurations.

source: https://developer.android.com/studio/releases/index.html#3-1-0