### PR TITLE
Fix app startup based on latest snapcraft changes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,3 +30,5 @@ parts:
   android-studio:
     plugin: dump
     source: https://dl.google.com/dl/android/studio/ide-zips/3.1.1.0/android-studio-ide-173.4697961-linux.zip
+    build-attributes:
+      - no-patchelf


### PR DESCRIPTION
Latest Android Studio won't start, this PR fixes it.

reference: https://forum.snapcraft.io/t/newly-built-android-studio-snap-wont-start/4940/2