### PR TITLE
remove architectures stanza

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,8 +11,6 @@ description: |
 
 grade: stable
 confinement: classic
-architectures:
-  - amd64
 
 apps:
   android-studio:


### PR DESCRIPTION
Same as https://github.com/snapcrafters/sublime-text/pull/10

Seems my understanding of `architectures` wasn't really clear. Landing this change won't have any impact as we don't ship **any** ubuntu packages with this snap, though we may in future.