### PR TITLE
Release version 3.1.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: android-studio
-version: '3.1.1.0'
+version: '3.1.2.0'
 summary: IDE for Android
 description: |
   Android Studio provides the fastest tools for building apps on every type
@@ -27,6 +27,6 @@ parts:
       - jetbrains-studio.desktop
   android-studio:
     plugin: dump
-    source: https://dl.google.com/dl/android/studio/ide-zips/3.1.1.0/android-studio-ide-173.4697961-linux.zip
+    source: https://dl.google.com/dl/android/studio/ide-zips/3.1.2.0/android-studio-ide-173.4720617-linux.zip
     build-attributes:
       - no-patchelf


### PR DESCRIPTION
Change log from https://developer.android.com/studio/releases/
```
3.1.2 (April 2018)

This update to Android Studio 3.1 includes fixes for the following bugs:

In some cases, Android Studio hung indefinitely during exit.
Builds configured with source sets failed with the following message when Instant Run was enabled:

"The SourceSet name is not recognized by the Android Gradle Plugin."

When Instant Run was enabled, builds of new Kotlin projects failed when triggered by the Run command.
During editing of the build.gradle file, there was sometimes a noticeable delay between typing a character and the character appearing on the screen.
Build failures occurred during dexing in some projects with large numbers of modules or external dependencies, with the following error message:

"RejectedExecutionException: Thread limit exceeded replacing blocked worker"

The computation of the D8 main DEX list was not taking into account some reflective invocations.
This update also includes changes that make running lint checks from Gradle much faster in some scenarios.
```