### PR TITLE
Enable CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+sudo: true
+dist: xenial
+
+before_script:
+  - sudo apt install snapd -y
+  - sudo snap install snapcraft --classic
+
+script:
+  - snapcraft
+  - ls -la

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: true
 dist: xenial
 
 before_script:
-  - sudo apt install snapd -y
   - sudo snap install snapcraft --classic
 
 script:
   - snapcraft
-  - ls -la


### PR DESCRIPTION
* Adds Travis config
* Currently only builds the snap on Xenial

Further CI cases like installing the snap and ensuring the executables inside have the same md5sum/sha256sum as from the original source.

I did a run on my local branch and all is good https://travis-ci.org/om26er/android-studio/jobs/384194055

We now need someone with "right" permissions to enable Travis CI for this project.