### PR TITLE
Add the GNOME 3.26 backport PPA

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,14 @@ apps:
     desktop: jetbrains-studio.desktop
 
 parts:
+  gnome:
+    plugin: nil
+    build-packages:
+      - software-properties-common
+    override-pull: |
+      add-apt-repository -y ppa:ubuntu-desktop/gnome-3-26
+      apt -y update
+      apt -y upgrade
   desktop:
     after:
       - android-studio
@@ -30,6 +38,7 @@ parts:
     prime:
       - jetbrains-studio.desktop
   android-studio:
+    after: [gnome]
     plugin: nil
     override-build: |
       snapcraftctl build


### PR DESCRIPTION
This pull request enables the GNOME 3.26 PPA supported by the Ubuntu Desktop team. This fixes access to user fonts and also theme integration. Thanks @kenvandine!