### PR TITLE
Fix upstream download as its now a tar.gz instead of zip

### DIFF
--- a/get_latest.py
+++ b/get_latest.py
@@ -10,7 +10,7 @@ def get_latest_studio_url():
     with urllib.request.urlopen(URL_STUDIO_HOME) as response:
         html = response.read().decode()
 
-    matched = re.findall('"((https)?://.*linux.zip)"', html)
+    matched = re.findall('"((https)?://.*linux.tar.gz)"', html)
     # Ensure unique and then convert to a list of easy access.
     links = list(set(matched))
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,13 +48,12 @@ parts:
       echo $VERSION > $SNAPCRAFT_STAGE/version
       DOWNLOAD_URL=$(echo ${RELEASE_INFO} | cut -d ' ' -f2)
 
-      wget --quiet "${DOWNLOAD_URL}" -O "${SNAPCRAFT_PART_INSTALL}/android-studio.zip"
-      unzip -q "${SNAPCRAFT_PART_INSTALL}/android-studio.zip" -d "${SNAPCRAFT_PART_INSTALL}"
+      wget --quiet "${DOWNLOAD_URL}" -O "${SNAPCRAFT_PART_INSTALL}/android-studio.tar.gz"
+      tar -xf "${SNAPCRAFT_PART_INSTALL}/android-studio.tar.gz" -C "${SNAPCRAFT_PART_INSTALL}"
 
       # Cleanup
-      rm "${SNAPCRAFT_PART_INSTALL}/android-studio.zip"
+      rm "${SNAPCRAFT_PART_INSTALL}/android-studio.tar.gz"
     build-packages:
-      - unzip
       - wget
       - python3
     build-attributes:


### PR DESCRIPTION
So apparently google is now shipping a tar instead of a zip file. Our script previously looked for the zip so the build was failing, this should fix that.