### PR TITLE
Dont upload to transfer.sh (fix CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ script:
   - export PATH=/snap/bin:$PATH
   - sudo snapcraft cleanbuild
   - sudo cp *.snap "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
-after_success:
-  - sudo snap install transfer
-  - timeout 180 sudo /snap/bin/transfer "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
 after_failure:
   - sudo journalctl -u snapd
   - sudo snap install http


### PR DESCRIPTION
Transfer.sh has issues and is going away by the end of October, lets get rid of that.