### PR TITLE
Fixed path to pulse socket

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ apps:
   android-studio:
     command: android-studio/bin/studio.sh
     environment:
-      PULSE_SERVER: $XDG_RUNTIME_DIR/../pulse/native
+      PULSE_SERVER: $XDG_RUNTIME_DIR/pulse/native
 
 parts:
   android-studio:


### PR DESCRIPTION
The current `PULSE_SERVER` setting doesn't work and misses the location of the pulse socket (see [this SO comment and reply](https://stackoverflow.com/questions/60356100/android-emulator-no-sound-in-ubuntu/64752489?noredirect=1#comment122781103_64752489)), but is also wrong if you consult the spec - https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html :

> `$XDG_RUNTIME_DIR` defines the **base directory** relative to which user-specific non-essential runtime files and other file objects (such as sockets, named pipes, ...) should be stored. The directory MUST be owned by the user, and he MUST be the only one having read and write access to it. Its Unix access mode MUST be 0700.

(emphasis mine)

If `$XDG_RUNTIME_DIR` is the base directory, you shouldn't go above it. And as expected - on a fresh OS install, using the path `$XDG_RUNTIME_DIR/../pulse/native` results in `/run/user/pulse/native`, which is not a thing that exists.

I'm not sure what originally caused PR #74 to be accepted, but either there was a bug in some older Ubuntu version that caused `$XDG_RUNTIME_DIR` to be set to something weird, or there was a local configuration change in @om26er 's machine and there was no verification of the change on other installations.