### PR TITLE
[workflow]: remove the space and add `-` in the version

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -24,6 +24,6 @@ jobs:
           update-script: |
             source_url="$(curl -sL https://developer.android.com/studio/index.html | grep -Eo '"((https)?://.*linux.tar.gz)"' | tr -d '"')"
             codename="$(curl -sL https://developer.android.com/studio/index.html | grep -Po 'Download Android Studio (?!today)[A-Za-z0-9]+' | head -n1 | cut -d ' ' -f4)"
-            version="$(basename "$source_url" .tar.gz | grep -oP '\d+\.\d+\.\d+\.\d+') $codename"
+            version="$(basename "$source_url" .tar.gz | grep -oP '\d+\.\d+\.\d+\.\d+')-$codename"
             sed -i "s|source: .*$|source: $source_url|g" snap/snapcraft.yaml 
             sed -i 's/^\(version: \).*$/\1'"\"$version\""'/' snap/snapcraft.yaml


### PR DESCRIPTION
Snapcraft doesn't like space in the `version` string :-(