### PR TITLE
Refresh Android Studio stable packaging and updater

### DIFF
--- a/.github/workflows/snap-build.yml
+++ b/.github/workflows/snap-build.yml
@@ -1,0 +1,101 @@
+name: Build and smoke test snap
+
+on:
+  push:
+  pull_request:
+    branches: ["candidate"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build snap
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: Show Snapcraft log on build failure
+        if: failure()
+        run: cat /home/runner/.local/state/snapcraft/log/snapcraft*.log
+
+      - name: Review snap
+        uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: "true"
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-studio-snap
+          path: ${{ steps.build.outputs.snap }}
+          retention-days: 7
+
+  smoke-test:
+    name: Launch snap and capture screenshots
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-studio-snap
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up LXD
+        uses: canonical/setup-lxd@v0.1.1
+
+      - name: Install ghvmctl
+        run: |
+          sudo snap install ghvmctl
+          sudo snap connect ghvmctl:lxd lxd:lxd
+
+      - name: Prepare VM
+        run: ghvmctl prepare
+
+      - name: Install local snap in VM
+        run: |
+          set -eux
+          SNAP_FILE=$(find . -maxdepth 1 -name '*.snap' | head -n 1)
+          VM_NAME=$(ghvmctl exec -- hostname | tr -d '\n')
+          lxc file push "$SNAP_FILE" "local:${VM_NAME}/home/ubuntu/$(basename "$SNAP_FILE")"
+          ghvmctl exec -- sudo snap install --dangerous --classic "/home/ubuntu/$(basename "$SNAP_FILE")"
+
+      - name: Launch Android Studio
+        run: |
+          ghvmctl snap-run android-studio.android-studio
+          sleep 90
+
+      - name: Capture screenshots
+        if: always()
+        run: |
+          ghvmctl screenshot-full
+          ghvmctl screenshot-window
+          ls -lh "$HOME/ghvmctl-screenshots/" || true
+
+      - name: Show app logs
+        if: always()
+        run: ghvmctl exec -- cat /home/ubuntu/android-studio.android-studio.log 2>/dev/null || true
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: android-studio-screenshots
+          path: ~/ghvmctl-screenshots/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/snap-build.yml
+++ b/.github/workflows/snap-build.yml
@@ -53,9 +53,10 @@ jobs:
 
       - name: Enable KVM
         run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0660", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+          sudo setfacl -m "u:${USER}:rw" /dev/kvm
 
       - name: Set up LXD
         uses: canonical/setup-lxd@v0.1.1

--- a/.github/workflows/snap-build.yml
+++ b/.github/workflows/snap-build.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: android-studio-snap
+          path: .
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -27,5 +27,5 @@ jobs:
             source_version="$(printf '%s' "$source_url" | sed -E 's#^.*/ide-zips/([0-9.]+)/.*#\1#')"
             source_file="$(basename "$source_url" .tar.gz)"
             version="${source_version}-$(printf '%s' "$source_file" | sed -E 's/^android-studio-//; s/-linux$//')"
-            sed -i "s|source: .*$|source: $source_url|g" snap/snapcraft.yaml 
+            sed -i "s|source: .*$|source: $source_url|g" snap/snapcraft.yaml
             sed -i 's/^\(version: \).*$/\1'"\"$version\""'/' snap/snapcraft.yaml

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -22,8 +22,10 @@ jobs:
         with:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
-            source_url="$(curl -sL https://developer.android.com/studio/index.html | grep -Eo '"((https)?://.*linux.tar.gz)"' | tr -d '"')"
-            codename="$(curl -sL https://developer.android.com/studio/index.html | grep -Po 'Download Android Studio (?!today)[A-Za-z0-9]+' | head -n1 | cut -d ' ' -f4)"
-            version="$(basename "$source_url" .tar.gz | grep -oP '\d+\.\d+\.\d+\.\d+')-$codename"
+            release_page="$(curl -sL https://developer.android.com/studio/releases)"
+            source_url="$(printf '%s' "$release_page" | grep -oP 'https://edgedl\.me\.gvt1\.com/android/studio/ide-zips/\d+\.\d+\.\d+\.\d+/android-studio-[^"]+-linux\.tar\.gz' | head -n1)"
+            source_version="$(printf '%s' "$source_url" | sed -E 's#^.*/ide-zips/([0-9.]+)/.*#\1#')"
+            source_file="$(basename "$source_url" .tar.gz)"
+            version="${source_version}-$(printf '%s' "$source_file" | sed -E 's/^android-studio-//; s/-linux$//')"
             sed -i "s|source: .*$|source: $source_url|g" snap/snapcraft.yaml 
             sed -i 's/^\(version: \).*$/\1'"\"$version\""'/' snap/snapcraft.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: android-studio
-version: "2025.2.3.9-wallpapers"
+version: "2025.3.3.7-panda3-patch1"
 summary: The IDE for Android
 description: |
   Android Studio provides the fastest tools for building apps on every type
@@ -22,6 +22,6 @@ apps:
 parts:
   android-studio:
     plugin: dump
-    source: https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.2.3.9/android-studio-2025.2.3.9-linux.tar.gz
+    source: https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.3.7/android-studio-panda3-patch1-linux.tar.gz
     build-attributes:
       - no-patchelf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: android-studio
-version: "2025.3.3.7-panda3-patch1"
+version: "2025.3.4.6-panda4"
 summary: The IDE for Android
 description: |
   Android Studio provides the fastest tools for building apps on every type
@@ -22,6 +22,6 @@ apps:
 parts:
   android-studio:
     plugin: dump
-    source: https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.3.7/android-studio-panda3-patch1-linux.tar.gz
+    source: https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.4.6/android-studio-panda4-linux.tar.gz
     build-attributes:
       - no-patchelf


### PR DESCRIPTION
## Summary
- refresh the snap to Android Studio Panda 4 | 2025.3.4
- fix the update workflow to scrape the stable Linux tarball from the releases page instead of matching the wallpapers download link
- add branch-friendly GitHub Actions that build the classic snap, review it, launch it in a VM, and upload screenshots

## Validation
- previous branch workflow run 24635301076 passed for the same packaging/update-workflow changes on the earlier stable release
- follow-up branch commit 8c565c9 updates the source tarball and version to Panda 4 | 2025.3.4 and has triggered a fresh workflow run on the fork