### PR TITLE
fix: bump version to 2025.3.4.6-panda4 and fix update workflow

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -22,8 +22,10 @@ jobs:
         with:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
-            source_url="$(curl -sL https://developer.android.com/studio/index.html | grep -Eo '"((https)?://.*linux.tar.gz)"' | tr -d '"')"
-            codename="$(curl -sL https://developer.android.com/studio/index.html | grep -Po 'Download Android Studio (?!today)[A-Za-z0-9]+' | head -n1 | cut -d ' ' -f4)"
-            version="$(basename "$source_url" .tar.gz | grep -oP '\d+\.\d+\.\d+\.\d+')-$codename"
-            sed -i "s|source: .*$|source: $source_url|g" snap/snapcraft.yaml 
+            release_page="$(curl -sL https://developer.android.com/studio/releases)"
+            source_url="$(printf '%s' "$release_page" | grep -oP 'https://edgedl\.me\.gvt1\.com/android/studio/ide-zips/\d+\.\d+\.\d+\.\d+/android-studio-[^"]+-linux\.tar\.gz' | head -n1)"
+            source_version="$(printf '%s' "$source_url" | sed -E 's#^.*/ide-zips/([0-9.]+)/.*#\1#')"
+            source_file="$(basename "$source_url" .tar.gz)"
+            version="${source_version}-$(printf '%s' "$source_file" | sed -E 's/^android-studio-//; s/-linux$//')"
+            sed -i "s|source: .*$|source: $source_url|g" snap/snapcraft.yaml
             sed -i 's/^\(version: \).*$/\1'"\"$version\""'/' snap/snapcraft.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: android-studio
-version: "2025.3.4.6-panda4"
+version: "2025.3.4.7-panda4-patch1"
 summary: The IDE for Android
 description: |
   Android Studio provides the fastest tools for building apps on every type
@@ -22,6 +22,6 @@ apps:
 parts:
   android-studio:
     plugin: dump
-    source: https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.4.6/android-studio-panda4-linux.tar.gz
+    source: https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.4.7/android-studio-panda4-patch1-linux.tar.gz
     build-attributes:
       - no-patchelf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: android-studio
-version: "2025.2.3.9-wallpapers"
+version: "2025.3.4.6-panda4"
 summary: The IDE for Android
 description: |
   Android Studio provides the fastest tools for building apps on every type
@@ -22,6 +22,6 @@ apps:
 parts:
   android-studio:
     plugin: dump
-    source: https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.2.3.9/android-studio-2025.2.3.9-linux.tar.gz
+    source: https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.4.6/android-studio-panda4-linux.tar.gz
     build-attributes:
       - no-patchelf


### PR DESCRIPTION
Picks up the version bump and update workflow fix from #176, without the snap-build CI workflow (which is not yet accurate).

Changes:
- **snap/snapcraft.yaml**: bump version `2025.2.3.9-wallpapers` → `2025.3.4.6-panda4` and update the source tarball URL
- **.github/workflows/sync-upstream.yml**: replace the update script to scrape the releases page instead of the download page, and derive the version/codename from the tarball filename directly — the old script no longer reliably finds a tarball URL from the download page

The new update script logic:
```bash
release_page="$(curl -sL https://developer.android.com/studio/releases)"
source_url="$(printf '%s' "$release_page" | grep -oP 'https://edgedl\.me\.gvt1\.com/android/studio/ide-zips/\d+\.\d+\.\d+\.\d+/android-studio-[^"]+linux\.tar\.gz' | head -n1)"
source_version="$(printf '%s' "$source_url" | sed -E 's#^.*/ide-zips/([0-9.]+)/.*#\1#')"
source_file="$(basename "$source_url" .tar.gz)"
version="${source_version}-$(printf '%s' "$source_file" | sed -E 's/^android-studio-//; s/-linux$//')"
```